### PR TITLE
stop bringing in the paper-styles kitchen sink

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0",
-    "web-component-tester": "*",
+    "web-component-tester": "polymer/web-component-tester#^3.4.0",
     "test-fixture": "polymerelements/test-fixture#^1.0.0",
     "iron-component-page": "PolymerElements/iron-component-page#^1.0.0"
   }

--- a/demo/index.html
+++ b/demo/index.html
@@ -17,16 +17,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes">
 
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
-  <link rel="import" href="../../iron-flex-layout/classes/iron-flex-layout.html">
+  <link rel="import" href="../../iron-flex-layout/iron-flex-layout.html">
   <link rel="import" href="../../paper-styles/typography.html">
   <link rel="import" href="../paper-material.html">
-
   <link rel="stylesheet" href="../../paper-styles/demo.css">
 
 </head>
 <body unresolved>
   <template is="dom-bind" id="demo">
-    <style>
+    <style is="custom-style">
       paper-material {
         display: inline-block;
         background: white;
@@ -47,6 +46,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         border-radius: 50%;
         text-align: center;
         cursor: pointer;
+        @apply(--layout-center-center);
       }
     </style>
     <section>
@@ -84,7 +84,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         tap
       </paper-material>
 
-      <paper-material class="fab layout center-center" elevation="0" animated>
+      <paper-material class="fab" elevation="0" animated>
         tap
       </paper-material>
     </section>

--- a/test/paper-material.html
+++ b/test/paper-material.html
@@ -16,9 +16,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <script src="../../webcomponentsjs/webcomponents.js"></script>
   <script src="../../web-component-tester/browser.js"></script>
-  <script src="../../test-fixture/test-fixture-mocha.js"></script>
-
-  <link href="../../test-fixture/test-fixture.html" rel="import">
   <link href="../paper-material.html" rel="import">
 
 </head>


### PR DESCRIPTION
Fixes the generic usage of `paper-styles.html` and `/deep/` classes and uses the specific imports instead. Also updates the test to the new `wct#^3.4.0` way