### PR TITLE
split elevation styles into separate stylesheet

### DIFF
--- a/paper-material-shared-styles.html
+++ b/paper-material-shared-styles.html
@@ -1,0 +1,40 @@
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<dom-module id="paper-material-shared-styles">
+  <template>
+    <style>
+      :host {
+        display: block;
+        position: relative;
+      }
+
+      :host([elevation="1"]) {
+        @apply(--shadow-elevation-2dp);
+      }
+
+      :host([elevation="2"]) {
+        @apply(--shadow-elevation-4dp);
+      }
+
+      :host([elevation="3"]) {
+        @apply(--shadow-elevation-6dp);
+      }
+
+      :host([elevation="4"]) {
+        @apply(--shadow-elevation-8dp);
+      }
+
+      :host([elevation="5"]) {
+        @apply(--shadow-elevation-16dp);
+      }
+    </style>
+  </template>
+</dom-module>

--- a/paper-material.html
+++ b/paper-material.html
@@ -10,6 +10,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../paper-styles/shadow.html">
+<link rel="import" href="paper-material-shared-styles.html">
 
 <!--
 Material design: [Cards](https://www.google.com/design/spec/components/cards.html)
@@ -29,34 +30,10 @@ Example:
 
 <dom-module id="paper-material">
   <template>
+    <style include="paper-material-shared-styles"></style>
     <style>
-      :host {
-        display: block;
-        position: relative;
-      }
-
       :host([animated]) {
         @apply(--shadow-transition);
-      }
-
-      :host([elevation="1"]) {
-        @apply(--shadow-elevation-2dp);
-      }
-
-      :host([elevation="2"]) {
-        @apply(--shadow-elevation-4dp);
-      }
-
-      :host([elevation="3"]) {
-        @apply(--shadow-elevation-6dp);
-      }
-
-      :host([elevation="4"]) {
-        @apply(--shadow-elevation-8dp);
-      }
-
-      :host([elevation="5"]) {
-        @apply(--shadow-elevation-16dp);
       }
     </style>
 


### PR DESCRIPTION
We recently did a refactor where elements that need to have a `paper-material` look, don't use a `paper-material` child, they just apply its styles. Most of these elements don't have an `animated` property, so they don't need its style either.

Needed to fix https://github.com/PolymerElements/paper-fab/issues/34