### PR TITLE
Restyle elevation 5 as 12dp; add elevation 6

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -43,6 +43,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         <paper-material elevation="3">3</paper-material>
         <paper-material elevation="4">4</paper-material>
         <paper-material elevation="5">5</paper-material>
+        <paper-material elevation="6">6</paper-material>
       </template>
     </demo-snippet>
 
@@ -66,7 +67,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             var target = e.target;
             if (!target.down) {
               target.elevation += 1;
-              if (target.elevation === 5) {
+              if (target.elevation === 6) {
                 target.down = true;
               }
             } else {

--- a/paper-material-shared-styles.html
+++ b/paper-material-shared-styles.html
@@ -35,6 +35,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
       :host([elevation="5"]) {
+        @apply(--shadow-elevation-12dp);
+      }
+
+      :host([elevation="6"]) {
         @apply(--shadow-elevation-16dp);
       }
     </style>

--- a/test/paper-material.html
+++ b/test/paper-material.html
@@ -33,6 +33,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <paper-material elevation="3"></paper-material>
       <paper-material elevation="4"></paper-material>
       <paper-material elevation="5"></paper-material>
+      <paper-material elevation="6"></paper-material>
     </template>
   </test-fixture>
 
@@ -69,7 +70,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           var lastStyle;
           var style;
 
-          expect(cards.length).to.be.eql(5);
+          expect(cards.length).to.be.eql(6);
 
           cards.forEach(function (card) {
             style = window.getComputedStyle(card);


### PR DESCRIPTION
Required to update the raised elevation for paper-fab. See https://github.com/PolymerElements/paper-fab/issues/35

_Technically_ this is a breaking change for anyone who uses `elevation="5"` (it is now a 12dp shadow instead of 16dp), but AFAIK none of our elements rely on this, and this purely cosmetic change will have little impact where it is used.